### PR TITLE
Pot très confiné Décembre 2020

### DIFF
--- a/cogs/pot_tres_confine.py
+++ b/cogs/pot_tres_confine.py
@@ -79,6 +79,7 @@ class CogPotTresConfine(commands.Cog):
 
         # Create the right number of lobbies
         for i in range(int((nb_users / max_by_channel)) + 1):
+            await ctx.guild.create_text_channel(f"lobby-{i + 1}", category=category)
             await ctx.guild.create_voice_channel(f"lobby-{i + 1}", category=category)
 
         voice_channels = category.voice_channels
@@ -100,7 +101,9 @@ class CogPotTresConfine(commands.Cog):
         category = MyUtils(ctx.guild).getPotTresConfineCategory()
         general_channel_id = discord.utils.get(category.voice_channels, name="General").id
         voice_channel = category.voice_channels
+        text_channel = category.text_channels
         voice_channel.pop(0)
+        text_channel.pop(0)
 
         for i in range(len(voice_channel)):
             members = voice_channel[i].voice_states
@@ -108,6 +111,7 @@ class CogPotTresConfine(commands.Cog):
                 member = await ctx.guild.fetch_member(member_id)
                 await member.move_to(self.bot.get_channel(general_channel_id))
             await voice_channel[i].delete()
+            await text_channel[i].delete()
 
     @commands.command()
     @has_orga_soiree_role()

--- a/cogs/pot_tres_confine.py
+++ b/cogs/pot_tres_confine.py
@@ -102,6 +102,8 @@ class CogPotTresConfine(commands.Cog):
         general_channel_id = discord.utils.get(category.voice_channels, name="General").id
         voice_channel = category.voice_channels
         voice_channel.pop(0)
+        text_channel = category.text_channels
+        text_channel.pop(0)
 
         for i in range(len(voice_channel)):
             members = voice_channel[i].voice_states
@@ -109,6 +111,7 @@ class CogPotTresConfine(commands.Cog):
                 member = await ctx.guild.fetch_member(member_id)
                 await member.move_to(self.bot.get_channel(general_channel_id))
             await voice_channel[i].delete()
+            await text_channel[i].delete()
 
     @commands.command()
     @has_orga_soiree_role()

--- a/cogs/pot_tres_confine.py
+++ b/cogs/pot_tres_confine.py
@@ -9,6 +9,7 @@ from random import shuffle
 import discord
 from discord.ext import commands
 from myutils import MyUtils
+import math
 
 
 def setup(bot: commands.bot.Bot):
@@ -78,7 +79,7 @@ class CogPotTresConfine(commands.Cog):
         nb_users = len(member_ids)
 
         # Create the right number of lobbies
-        for i in range(int((nb_users / max_by_channel))):
+        for i in range(math.ceil(nb_users / max_by_channel)):
             await ctx.guild.create_text_channel(f"lobby-{i + 1}", category=category)
             await ctx.guild.create_voice_channel(f"lobby-{i + 1}", category=category)
 

--- a/cogs/pot_tres_confine.py
+++ b/cogs/pot_tres_confine.py
@@ -101,8 +101,8 @@ class CogPotTresConfine(commands.Cog):
         category = MyUtils(ctx.guild).getPotTresConfineCategory()
         general_channel_id = discord.utils.get(category.voice_channels, name="General").id
         voice_channel = category.voice_channels
-        voice_channel.pop(0)
         text_channel = category.text_channels
+        voice_channel.pop(0)
         text_channel.pop(0)
 
         for i in range(len(voice_channel)):


### PR DESCRIPTION
Création de lobbys vocaux et textuels pour le Pot TC de décembre 2020
Possibilité de mute et de demute les participants, ainsi que de les répartir automatiquement.

&create_pot
&repartition
&rassemblement
&destroy_pot
&mute_all
&demute_all

